### PR TITLE
feat(logical-type): add support for the logical type 'decimal'

### DIFF
--- a/example/standard_cap-value.avsc
+++ b/example/standard_cap-value.avsc
@@ -184,6 +184,15 @@
               }
             },
             {
+              "name": "amount",
+              "type": {
+                "type": "bytes",
+                "logicalType": "decimal",
+                "precision": 5,
+                "scale": 3
+              }
+            },
+            {
               "name": "audience",
               "type": ["null", "string"],
               "default": null

--- a/src/avro-typescript/index.ts
+++ b/src/avro-typescript/index.ts
@@ -9,6 +9,7 @@ import {
   RecordType,
   EnumType,
   isOptional,
+  isLogicalDecimalType,
 } from './model';
 import { createDocumentation } from '../utils';
 export { RecordType } from './model';
@@ -107,6 +108,8 @@ const convertType = (type: Type, hasDefaultValue: boolean, buffer: string[], par
   } else if (isEnumType(type)) {
     // array, call recursively for the array element type
     return convertEnum(type, buffer);
+  } else if (isLogicalDecimalType(type)) {
+    return 'number';
   } else {
     console.error('Cannot work out type', type);
     return 'UNKNOWN';

--- a/src/avro-typescript/model.ts
+++ b/src/avro-typescript/model.ts
@@ -41,6 +41,13 @@ export interface NamedType extends BaseType {
   type: string;
 }
 
+export interface LogicalDecimalType extends BaseType {
+  type: 'bytes',
+  logicalType: 'decimal',
+  precision: number;
+  scale: number;
+}
+
 export const isRecordType = (type: BaseType): type is RecordType => type.type === 'record';
 
 export const isArrayType = (type: BaseType): type is ArrayType => type.type === 'array';
@@ -48,6 +55,10 @@ export const isArrayType = (type: BaseType): type is ArrayType => type.type === 
 export const isMapType = (type: BaseType): type is MapType => type.type === 'map';
 
 export const isEnumType = (type: BaseType): type is EnumType => type.type === 'enum';
+
+export const isLogicalDecimalType = (type: BaseType): type is LogicalDecimalType => {
+  return type.type === 'bytes' && (type as LogicalDecimalType).logicalType === 'decimal';
+}
 
 export const isUnion = (type: Type): type is NamedType[] => type instanceof Array;
 


### PR DESCRIPTION
Avro has logical types, where one of them is 'decimal'. The base type is 'bytes'. So any number will be converted from a javascript number into a bytes buffer. When decoded it will be converted back into a javascript number